### PR TITLE
Nazev pluginu

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -3,7 +3,7 @@
 # This file should be included when you package your plugin.# Mandatory items:
 
 [general]
-name=qgis-jvf-dmvs-plugin
+name=JVF DTM Plugin
 qgisMinimumVersion=3.0
 version=0.1
 author=Linda Karlovská, Petr Barandovski


### PR DESCRIPTION
Predpokladam, ze casem se plugin objevi v repozitari QGIS a rada uzivatelu bude plugin vyhledavat pomoci klicoveho slova `DTM`. Aktualni nazev tomu nepomaha

![Screenshot From 2025-02-24 11-41-51](https://github.com/user-attachments/assets/91e554c9-e166-44d4-95c2-835ce94a3b84)

Toto PR meni nazev na `JFV DTM Plugin` nebo vas napada vhodnejsi nazev?

![Screenshot From 2025-02-24 11-43-20](https://github.com/user-attachments/assets/8eec2518-f59a-4c6f-ad86-5b587c599bef)
